### PR TITLE
Fix formatter type error

### DIFF
--- a/bootrom.c
+++ b/bootrom.c
@@ -82,13 +82,13 @@ uint64_t bootrom_load(void)
 	 * MMIO space (e.g. APIC, HPET, MSI).
 	 */
 	if (sbuf.st_size > MAX_BOOTROM_SIZE || sbuf.st_size < XHYVE_PAGE_SIZE) {
-		fprintf(stderr, "Invalid bootrom size %zd\n", sbuf.st_size);
+		fprintf(stderr, "Invalid bootrom size %lld\n", (long long)sbuf.st_size);
 		goto done;
 	}
 
 	if (sbuf.st_size & XHYVE_PAGE_MASK) {
-		fprintf(stderr, "Bootrom size %zd is not a multiple of the "
-		    "page size\n", sbuf.st_size);
+		fprintf(stderr, "Bootrom size %lld is not a multiple of the "
+		    "page size\n", (long long)sbuf.st_size);
 		goto done;
 	}
 
@@ -98,8 +98,8 @@ uint64_t bootrom_load(void)
 	ptr = vmm_mem_alloc(gpa, (size_t)sbuf.st_size);
 	if (!ptr) {
 		fprintf(stderr,
-			"Failed to allocate %zd bytes of memory for bootrom\n",
-			sbuf.st_size);
+			"Failed to allocate %lld bytes of memory for bootrom\n",
+			(long long)sbuf.st_size);
 		rv = -1;
 		goto done;
 	}


### PR DESCRIPTION
I get the following errors:
```
bootrom.c:85:49: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'off_t' (aka 'long long') [-Wformat]
bootrom.c:91:22: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'off_t' (aka 'long long') [-Wformat]
bootrom.c:102:4: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'off_t' (aka 'long long') [-Wformat]
```

Source: https://github.com/moby/hyperkit/pull/201/files